### PR TITLE
Typo in ReadMe and java compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ mvn clean package
 
 it will package compiled classes and its dependencies into a jar.
 
-### run the consumer
+### Run the Producer
+This example also contains two producers written in Java and in scala.
+you can run this for java:
+``` sh
+java -cp kafka_example-0.1.0-SNAPSHOT.jar com.colobu.kafka.ProducerExample 10000 test_topic localhost:9092
+```
+or this for scala
+``` sh
+java -cp kafka_example-0.1.0-SNAPSHOT.jar com.colobu.kafka.ScalaProducerExample 10000 test_topic localhost:9092
+```
+
+### Run the Consumer
 This example contains two consumers written in Java and in scala.
 You can run this for java:
 ``` sh
@@ -38,13 +49,4 @@ or this for scala:
 java -cp kafka_example-0.1.0-SNAPSHOT.jar com.colobu.kafka.ScalaConsumerExample localhost:2181 group1 test_topic 10 0
 ```
 
-### run the consumer
-This example also contains two producers written in Java and in scala.
-you can run this for java:
-``` sh
-java -cp kafka_example-0.1.0-SNAPSHOT.jar com.colobu.kafka.ProducerExample 10000 colobu localhost:9092
-```
-or this for scala
-``` sh
-java -cp kafka_example-0.1.0-SNAPSHOT.jar com.colobu.kafka.ScalaProducerExample 10000 colobu localhost:9092
-```
+

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Hi, 
I noticed a typo in Readme and I wanted to fix it, if that is okay with you.

Other people had the same error on their compiler. For some reason, maven try to use the version 1.3 
I added the `<properties>` that force it to use a newer java version
